### PR TITLE
Update to use the latest 1.x.x versions of the csslint node module

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "atom": ">0.174.0"
   },
   "dependencies": {
-    "csslint": "^0.10.0",
+    "csslint": "^1.0.0",
     "atom-message-panel": "1.2.7",
     "loophole": "^1.0.0"
   }


### PR DESCRIPTION
The CSSLint Atom package had got stuck on version 0.10.0 of the csslint node module.

This updates it so it can move on to the latest 1.x.x version of the csslint node module.

I've suggested this because I am doing an online web development course and the instructor mentioned that CSSLint would warn if our CSS properties were not in alphabetical order...but with the 0.10.0 version of the node module it does not.